### PR TITLE
Do not unnecessarily update packages when they must only be "present"

### DIFF
--- a/conda
+++ b/conda
@@ -155,11 +155,11 @@ def _remove_package(module, conda, installed, name):
 def _install_package(
         module, conda, installed, name, version, installed_version):
     """
-    Install a package at a specific version, or the latest version if no
-    version is specified.
+    Install a package at a specific version, or install a missing package at
+    the latest version if no version is specified.
 
     """
-    if installed and installed_version == version:
+    if installed and (version is None or installed_version == version):
         module.exit_json(changed=False, name=name, version=version)
 
     if module.check_mode:


### PR DESCRIPTION
To match the behavior of other Ansible modules, a package which is installed but outdated should not be updated unless its state is specified as "latest". The default state of "present" should only cause an installed package to be changed if a package version is also explicitly specified.
