### PR TITLE
Fix parsing of conda list output

### DIFF
--- a/conda.py
+++ b/conda.py
@@ -115,7 +115,7 @@ def _check_installed(module, conda, name):
     command = [
         conda,
         'list',
-        '^' + name + '$'
+        '^' + name + '$',
         '--json'
     ]
     command = _add_extras_to_command(command, module.params['extra_args'])

--- a/conda.py
+++ b/conda.py
@@ -113,8 +113,7 @@ def _check_installed(module, conda, name):
     """
     command = [
         conda,
-        'list',
-        '^' + name + '$'  # use regex to get an exact match
+        'list'
     ]
     command = _add_extras_to_command(command, module.params['extra_args'])
 
@@ -123,9 +122,19 @@ def _check_installed(module, conda, name):
     if rc != 0:
         return False, None
 
-    version = stdout.strip().split()[-2]
+    installed = False
+    version = None
+    
+    # Each line of output of `conda list` has the format:
+    # "requests                  2.11.1                   py35_0    defaults"
+    for line in stdout.strip().split('\n'):
+        if name in line:
+            match = line.split()
+            if name == match[0]: # an actual match
+                installed = True
+                version = match[1]
 
-    return True, version
+    return installed, version
 
 
 def _remove_package(module, conda, installed, name):


### PR DESCRIPTION
The format of conda list has changed, so this ansible module is broken. This fixes it to use `conda list --json`.