### PR TITLE
Patch for #10 and fixed changed boolean for unchanged "present" state

### DIFF
--- a/conda.py
+++ b/conda.py
@@ -211,6 +211,9 @@ def _install_package(
     if rc != 0:
         module.fail_json(msg='failed to install package ' + name)
 
+    if 'requested packages already installed' in stdout:
+        module.exit_json(changed=False, name=name)
+
     module.exit_json(
         changed=True, name=name, version=version, stdout=stdout, stderr=stderr)
 

--- a/conda.py
+++ b/conda.py
@@ -129,7 +129,7 @@ def _check_installed(module, conda, name):
     version = None
     
     data = json.loads(stdout)
-    if data:
+    if data and type(data[0]) is str:
         # At this point data will be a list of len 1, with the element of
         # the format: "channel::package-version-py35_1"
         line = data[0]
@@ -142,6 +142,11 @@ def _check_installed(module, conda, name):
         if pname == name: # verify match for safety
             installed = True
             version = pversion
+    elif data and type(data[0]) is dict:
+        # conda 4.3 now returns a dictionary
+        if data[0]['name'] == name:
+            installed = True
+            version = data[0]['version']
 
     return installed, version
 


### PR DESCRIPTION
Patch for #10. Also I noticed when requesting compatible version like 11.0.* for state='present', and no newer version is available, it's returning changed = True. I've modified it to check the presence of magic text to say changed = False (same way as for state='latest').