### PR TITLE
Fix Conda package uninstall error

### DIFF
--- a/conda.py
+++ b/conda.py
@@ -238,7 +238,7 @@ def run_conda_package_command(command_runner, name, version, command):
     try:
         return command_runner(command)
     except CondaCommandJsonDescribedError as e:
-        if 'exception_name' in e.output and e.output['exception_name'] == 'PackageNotFoundError':
+        if 'exception_name' in e.output and e.output['exception_name'] in ('PackageNotFoundError', 'PackagesNotFoundError'):
             raise CondaPackageNotFoundError(name, version)
         else:
             raise


### PR DESCRIPTION
Updated code to address the following error encountered when uninstalling a Conda package:
`{"changed": true, "cmd": ["/usr/local/anaconda-5.1.0/bin/conda", "remove", "-y", "curl"], "delta": "0:00:05.129115", "end": "2018-03-26 21:16:52.795504", "msg": "non-zero return code", "rc": 1, "start": "2018-03-26 21:16:47.666389", "stderr": "\nPackagesNotFoundError: The following packages are missing from the target environment:\n  - curl", "stderr_lines": ["", "PackagesNotFoundError: The following packages are missing from the target environment:", "  - curl"], "stdout": "Solving environment: ...working... failed", "stdout_lines": ["Solving environment: ...working... failed"]}`